### PR TITLE
LPS-143971 preview sidebar updates

### DIFF
--- a/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/src/main/resources/META-INF/resources/sxp_blueprint_admin/js/edit_sxp_blueprint/EditSXPBlueprintForm.js
@@ -698,12 +698,15 @@ function EditSXPBlueprintForm({
 			</PageToolbar>
 
 			<PreviewSidebar
+				errors={previewInfo.results.errors}
 				loading={previewInfo.loading}
 				onFetchResults={_handleFetchPreviewSearch}
 				onFocusSXPElement={_handleFocusSXPElement}
 				onToggle={setShowPreview}
-				results={previewInfo.results}
+				responseString={previewInfo.results.responseString}
+				totalHits={previewInfo.results.totalHits}
 				visible={showPreview}
+				warnings={previewInfo.results.warnings}
 			/>
 
 			<div

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/edit_sxp_blueprint/PreviewSidebar.js
@@ -26,14 +26,15 @@ jest.mock(
 
 Liferay.ThemeDisplay.getDefaultLanguageId = () => 'en_US';
 
-const SEARCH_RESULTS = mockSearchResults().response.hits.hits;
+const SEARCH_RESULTS = mockSearchResults();
+
+const SEARCH_RESULTS_HITS = JSON.parse(SEARCH_RESULTS.responseString).hits.hits;
 
 function renderPreviewSidebar(props) {
 	return render(
 		<PreviewSidebar
 			loading={false}
 			onFetchResults={jest.fn()}
-			results={mockSearchResults()}
 			visible={true}
 			{...props}
 		/>
@@ -50,10 +51,7 @@ describe('PreviewSidebar', () => {
 	});
 
 	it('renders the introduction', () => {
-		const {getByText} = renderPreviewSidebar({
-			loading: false,
-			results: {},
-		});
+		const {getByText} = renderPreviewSidebar();
 
 		getByText('perform-a-search-to-preview-your-blueprints-search-results');
 	});
@@ -61,27 +59,34 @@ describe('PreviewSidebar', () => {
 	it('renders the loading icon', () => {
 		const {container} = renderPreviewSidebar({
 			loading: true,
-			results: {},
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.totalHits,
 		});
 
 		container.querySelector('.loading-animation');
 	});
 
 	it('renders the titles for the search results', () => {
-		const {getByText} = renderPreviewSidebar();
+		const {getByText} = renderPreviewSidebar({
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.totalHits,
+		});
 
-		SEARCH_RESULTS.map((result) => {
+		SEARCH_RESULTS_HITS.map((result) => {
 			getByText(result.fields.title_en_US[0]);
 		});
 	});
 
 	it('expands the result when clicked on', () => {
-		const {getAllByLabelText, queryAllByText} = renderPreviewSidebar();
+		const {getAllByLabelText, queryAllByText} = renderPreviewSidebar({
+			responseString: SEARCH_RESULTS.responseString,
+			totalHits: SEARCH_RESULTS.totalHits,
+		});
 
 		fireEvent.click(getAllByLabelText('expand')[0]);
 
-		Object.keys(SEARCH_RESULTS[0].fields).map((key) => {
-			queryAllByText(`${SEARCH_RESULTS[0].fields[key][0]}`);
+		Object.keys(SEARCH_RESULTS_HITS[0].fields).map((key) => {
+			queryAllByText(`${SEARCH_RESULTS_HITS[0].fields[key][0]}`);
 		});
 	});
 
@@ -98,10 +103,8 @@ describe('PreviewSidebar', () => {
 		];
 
 		const {getByText} = renderPreviewSidebar({
+			errors,
 			loading: false,
-			results: {
-				errors,
-			},
 		});
 
 		errors.map((error) => getByText(error.msg));

--- a/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
+++ b/modules/dxp/apps/search-experiences/search-experiences-web/test/js/mocks/data.js
@@ -189,9 +189,8 @@ export function mockSearchResults(itemsPerPage = 10) {
 	return {
 		page: 0,
 		pageSize: itemsPerPage,
-		request: {},
 		requestString: '',
-		response: {
+		responseString: JSON.stringify({
 			hits: {
 				hits,
 				total: {
@@ -199,8 +198,7 @@ export function mockSearchResults(itemsPerPage = 10) {
 				},
 			},
 			timed_out: false,
-		},
-		responseString: '',
+		}),
 		totalHits: 1000,
 	};
 }


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-143971

Updates:
- Accounts for the results object for preview only having the following fields: `page`, `pageSize`, `requestString`, `responseString`, `totalHits`.
- `responseString` is parsed into JSON in order to render the search hits.
- Conditionals rely on `totalHits` instead of `results?.response?.hits?.hits`.
- Included a frontend change, where props for the `PreviewSidebar` have been updated to be more specific (doesn't just accept `results`, takes in `errors`, `warnings`,  `totalHits`, and `responseString`).
- Updated the related frontend tests.


@thektan