### PR TITLE
Add local storage

### DIFF
--- a/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
+++ b/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
@@ -19,6 +19,7 @@ interface AssistantChatProps {
 	formikValues: any;
 	greetingMessage?: string;
 	sidebarBodyHeight: number;
+	taskExternalReferenceCode: string;
 }
 
 interface Endpoints {
@@ -58,6 +59,7 @@ const AssistantChat = forwardRef(function AssistantChat({
 	assistantName = 'Assistant',
 	endpoints,
 	greetingMessage = 'Hi, I am your assistant. How can I help you?',
+	taskExternalReferenceCode,
 }: AssistantChatProps, ref) {
 	const [sidebarBodyHeight, setSidebarBodyHeight] = useState(802);
 
@@ -98,6 +100,12 @@ const AssistantChat = forwardRef(function AssistantChat({
 		if (sidebarElement) {
 			setSidebarBodyHeight(sidebarElement.offsetHeight - 64);
 		}
+
+		const localStorageChatHistory = localStorage.getItem(taskExternalReferenceCode);
+
+		if (localStorageChatHistory) {
+			setChatHistory(JSON.parse(localStorageChatHistory));
+		};
 	}, []);
 
 	useEffect(() => {
@@ -108,6 +116,13 @@ const AssistantChat = forwardRef(function AssistantChat({
 		if (messageBody) {
 			messageBody.scrollTop =
 				messageBody.scrollHeight - messageBody.clientHeight;
+		}
+
+		if (chatHistory.length) { 
+			localStorage.setItem(
+				taskExternalReferenceCode, 
+				JSON.stringify(chatHistory)
+			); 
 		}
 	}, [chatHistory]);
 

--- a/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
+++ b/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
@@ -10,7 +10,7 @@ import { ClayInput } from '@clayui/form';
 import ClayIcon from '@clayui/icon';
 import ClayLoadingIndicator from '@clayui/loading-indicator';
 import { fetch } from 'frontend-js-web';
-import React, { forwardRef, useEffect, useImperativeHandle, useState } from 'react';
+import React, { forwardRef, useEffect, useImperativeHandle, useRef, useState } from 'react';
 import ReactMarkdown from 'react-markdown';
 
 interface AssistantChatProps {
@@ -69,10 +69,18 @@ const AssistantChat = forwardRef(function AssistantChat({
 
 	const [prompt, setPrompt] = useState('');
 
+	const originalTaskExternalReferenceCode = useRef(taskExternalReferenceCode);
+
 	const clearChatHistory = () => {
 		setChatHistory([]);
 		localStorage.removeItem(taskExternalReferenceCode);
 	}
+
+	function renameLocalStorageKey(oldKey, newKey) {
+		const value: any = localStorage.getItem(oldKey);
+		localStorage.setItem(newKey, value);
+		localStorage.removeItem(oldKey);
+	  }
 
 	useImperativeHandle(ref, () => ({
 		clearChatHistory,
@@ -128,6 +136,13 @@ const AssistantChat = forwardRef(function AssistantChat({
 			); 
 		}
 	}, [chatHistory]);
+
+	useEffect(() => {
+		if (taskExternalReferenceCode !== originalTaskExternalReferenceCode.current) {
+			renameLocalStorageKey(originalTaskExternalReferenceCode.current, taskExternalReferenceCode);
+			originalTaskExternalReferenceCode.current = taskExternalReferenceCode;
+		}
+	}, [taskExternalReferenceCode])
 
 	const handleReceiveMessage = (value: any) => {
 		if (value) {

--- a/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
+++ b/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/assistant_chat/AssistantChat.tsx
@@ -69,10 +69,13 @@ const AssistantChat = forwardRef(function AssistantChat({
 
 	const [prompt, setPrompt] = useState('');
 
+	const clearChatHistory = () => {
+		setChatHistory([]);
+		localStorage.removeItem(taskExternalReferenceCode);
+	}
+
 	useImperativeHandle(ref, () => ({
-		clearChatHistory: () => {
-			setChatHistory([]);
-		}
+		clearChatHistory,
 	}));
 
 	const isInsideIframe = window.self !== window.top;

--- a/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/index.js
+++ b/modules/apps/generative-ai/generative-ai-web/src/main/resources/META-INF/resources/task_definitions_admin/js/edit_task_definition/preview_sidebar/index.js
@@ -191,6 +191,7 @@ function PreviewSidebar({
 					endpoints={{sendMessageEndpoint: `/o/generative-ai/v1.0/generate/${formikValues.externalReferenceCode}`}} 
 					greetingMessage="Try me!"
 					ref={AssistantChatRef}
+					taskExternalReferenceCode={formikValues.externalReferenceCode}
 				/>
 			</div>
 		</div>


### PR DESCRIPTION
- Chat history is stored on local storage and survives sections
- When you clear a chat history you are deleting the whole local storage's entry
- Renaming the task's external reference code also renames the local storage entry so you don't loose the history when editing the rask ERC.